### PR TITLE
Fix #495, fix #498, fix #500

### DIFF
--- a/api/policies/sessionAuth.js
+++ b/api/policies/sessionAuth.js
@@ -10,7 +10,7 @@
 module.exports = function(req, res, next) {
   if (req.user) {
     if (req.user.banned) {
-      req.logout();
+      req.session.destroy();
       return res.view(403, {error: "You have been banned from FlairHQ"});
     }
     return next();

--- a/assets/views/home/banlist.ejs
+++ b/assets/views/home/banlist.ejs
@@ -6,11 +6,15 @@
       <h2>Ban list</h2>
 
       <ul class="list-group col-md-6">
-        <li ng-repeat="user in <%= JSON.stringify(bannedUsers) %>" class="list-group-item row">
-          <div class="col-md-9">
-            <h4>{{user.name}}</h4>
-          </div>
-        </li>
+        <% for (var i = 0; i < bannedUsers.length; i++) { %>
+          <a href="/u/<%= bannedUsers[i].name %>" style="color:inherit;">
+            <li class="list-group-item row">
+              <div class="col-md-9">
+                <h4><%= bannedUsers[i].name %></h4>
+              </div>
+            </li>
+          </a>
+        <% } %>
       </ul>
     </div>
   </div>

--- a/assets/views/home/editreference.ejs
+++ b/assets/views/home/editreference.ejs
@@ -60,7 +60,7 @@
               <label for="number" class="col-md-4 control-label">Number given:</label>
 
               <div class="col-md-8">
-                <input type="text" class="form-control"
+                <input type="number" class="form-control"
                        ng-model="selectedRef.number"></input>
               </div>
             </div>

--- a/assets/views/home/index.ejs
+++ b/assets/views/home/index.ejs
@@ -58,7 +58,7 @@
 
           <ng-tooltip data-label="Number given" ng-show="hasNumber(addInfo.type)"
                       title="How many you gave away. This can be updated.">
-              <input type="text" class="form-control" ng-model="addInfo.number" value="<%= query.number || ''%>">
+              <input type="number" class="form-control" ng-model="addInfo.number" value="<%= query.number || ''%>">
           </ng-tooltip>
 
           <ng-tooltip data-label="Gave" ng-hide="isNotNormalTrade(addInfo.type)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlairHQ",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "A project to allow easy adding of flair applications for subreddits (focusing initially on /r/pokemontrades) and easy moderation for moderators.",
   "scripts": {
     "start": "node ./node_modules/sails/bin/sails.js lift"


### PR DESCRIPTION
Wow, this was a great bug.

We were rendering banned users in a somewhat inefficient way; we used a combination of angular and EJS. We got the array of banned users like this:

```html
<li ng-repeat="user in <%= JSON.stringify(bannedUsers) %>" class="list-group-item row">
```

The `bannedUsers` local was actually the entire user object rather than just the username, so after EJS compiled it, it looked like this:

```html
<li ng-repeat="user in {&quot;name&quot; : &quot;naa&quot; , &quot;intro&quot; : &quot;blah&quot; , ...}" class="list-group-item row">
```

This all worked fine, until there was a user that had the string " as " in their intro. Then the line got compiled to:

```html
<li ng-repeat="user in {&quot;name&quot; : &quot;naa&quot; , &quot;intro&quot; : &quot;blah as blah&quot; , ...}" class="list-group-item row">
```

Then angular noticed the " as " and decided that it must be a token (e.g. `ng-repeat="blah as blah for blah in blah"`. So it cut the JSON at that point (in the middle of a string), which prevented it from being parsed and caused it to throw an error.

...and that's why we now render the banlist serverside.