### PR TITLE
Fixed sails-hook-schedule, which broke since this is a leap month

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "request-promise": "^1.0.2",
     "sails": "~0.11.2",
     "sails-disk": "~0.10.8",
-    "sails-hook-schedule": "^0.2.1",
+    "sails-hook-schedule": "^0.2.2",
     "sails-mongo": "^0.11.4",
     "sails.io.js": "^0.11.7",
     "sha256": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "request-promise": "^1.0.2",
     "sails": "~0.11.2",
     "sails-disk": "~0.10.8",
+    "sails-hook-babel": "^5.0.1",
     "sails-hook-schedule": "^0.2.2",
     "sails-mongo": "^0.11.4",
     "sails.io.js": "^0.11.7",


### PR DESCRIPTION
Personally I find this hilarious.

Anyway, as a result of this, modmails haven't been archived since January 31st. I just updated the dependency on the server (by running npm upgrade), but we should still probably update the repo as well.

Update: I also fixed the sails-hook-babel issue, so now the app should build properly again.