### PR TITLE
Fix #517

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -207,7 +207,8 @@ module.exports = {
         var fc_match = /(\d{4}-){2}\d{4}/g;
         unique_fcs = _.union(flairs[0].flair_text.match(fc_match), flairs[1].flair_text.match(fc_match), unique_fcs);
       }
-      let igns = (flairs ? flairs : [user.flair.ptrades, user.flair.svex]).map(flair => flair.flair_text.split(' || ')[1]).join(', ');
+      let flair_texts = flairs ? _.map(flairs, 'flair_text') : [user.flair.ptrades.flair_text, user.flair.svex.flair_text];
+      let igns = _.compact(flair_texts).map(text => text.split(' || ')[1]).join(', ');
       var promises = [];
       if (flairs) {
         promises.push(Ban.banFromSub(req.user.redToken, req.params.username, req.params.banMessage, req.params.banNote, 'pokemontrades', req.params.duration));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlairHQ",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "A project to allow easy adding of flair applications for subreddits (focusing initially on /r/pokemontrades) and easy moderation for moderators.",
   "scripts": {
     "start": "node ./node_modules/sails/bin/sails.js lift"


### PR DESCRIPTION
The bug was occuring for users who had set their flair using Porygon2-Bot, before we started using FlairHQ for it. The ban function was trying to parse their flair text from svex to get their IGNs, but this caused `undefined` to appear in the list of IGNs if the user had no flair set on svex. The fix uses `_.compact` to remove empty flairs from the list of IGNs.