### PR TITLE
Get rid of the 'move to shiny section' button

### DIFF
--- a/assets/sharedClientFunctions.js
+++ b/assets/sharedClientFunctions.js
@@ -162,11 +162,5 @@ module.exports = {
         });
       }
     };
-    // Temporary convenience button to move formerly-bank trades to the shiny section, since people will probably need to do that a lot.
-    $scope.moveRefToShinySection = function (ref) {
-      ref.type = 'shiny';
-      $scope.selectedRef = ref;
-      $scope.editRef();
-    };
   }
 };

--- a/assets/views/home/row.ejs
+++ b/assets/views/home/row.ejs
@@ -2,7 +2,6 @@
   <strong>
     {{$index + 1}}.
   </strong>
-  <button ng-if="isBank(reference) && reference.user === user.name" class="btn btn-xs has-spinner" ng-click="moveRefToShinySection(reference)"><div title="This section used to include shinies and events from past generations, but now it only includes events. If this trade was here because it involved past-gen shinies, click here to move it up to the Shiny section instead. (This button is probably a temporary feature, since we know people will be moving a lot of things in the near future.)">Move to Shiny section</div></button>
 </td>
 
 <td ng-if="isTrade(reference)">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlairHQ",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "description": "A project to allow easy adding of flair applications for subreddits (focusing initially on /r/pokemontrades) and easy moderation for moderators.",
   "scripts": {
     "start": "node ./node_modules/sails/bin/sails.js lift"


### PR DESCRIPTION
It's been two months, so most people probably aren't using it anymore, and it was added as a temporary feature anyway.