### PR TITLE
Update npm version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
     fi
   - gcc --version
   - g++ --version
+  - npm i -g npm
 
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
It seems travis uses the bundled version of npm with node, so let's install the newest version, because it looks like we are having some semver bugs with the greenkeeper PR.