### PR TITLE
Fixed display of Gen II Ball's name and bumped version number

### DIFF
--- a/api/services/Flairs.js
+++ b/api/services/Flairs.js
@@ -14,6 +14,9 @@ exports.formattedName = function(name) {
   if (name.indexOf("ball") > -1) {
     suffix = "Ball";
     numberToSliceTill = -4;
+  } else if (name === "gen2") {
+    suffix = "II Ball";
+    numberToSliceTill = -1;
   } else if (name.indexOf("charm") > -1) {
     suffix = "Charm";
     numberToSliceTill = -5;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlairHQ",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A project to allow easy adding of flair applications for subreddits (focusing initially on /r/pokemontrades) and easy moderation for moderators.",
   "scripts": {
     "start": "node ./node_modules/sails/bin/sails.js lift"


### PR DESCRIPTION
Added another condition to the flair suffixes so that the new flair will be displayed as "Gen II Egg" rather than "Gen2 Egg" and bumped the version to 2.5.1.