### PR TITLE
Link to the trade instead of the user's reference page on search

### DIFF
--- a/assets/search/search.controller.js
+++ b/assets/search/search.controller.js
@@ -46,7 +46,7 @@ module.exports = function ($scope, $timeout) {
 
   function linkAddress (result) {
     if (vm.input.search === 'ref') {
-      return '/u/' + result.user;
+      return result.url;
     } else if (vm.input.search === 'user') {
       return '/u/' + result._id;
     } else if (vm.input.search === 'modmail') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlairHQ",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "A project to allow easy adding of flair applications for subreddits (focusing initially on /r/pokemontrades) and easy moderation for moderators.",
   "scripts": {
     "start": "node ./node_modules/sails/bin/sails.js lift"


### PR DESCRIPTION
This makes it so that trade search results link to the trade in question, rather than the user profile of whoever logged the trade.