### PR TITLE
Fix an issue where `undefined` could appear on the banlist

### DIFF
--- a/api/services/Flairs.js
+++ b/api/services/Flairs.js
@@ -182,7 +182,7 @@ exports.legalIgn = '[^()|,]{0,11}[^()|,\\s]';
 // Parse the games. e.g. 'ExampleName (X, Y)' --> [{ign: 'ExampleName', game: 'X'}, {ign: 'ExampleName', game: 'Y'}]
 exports.parseGames = function (formatted_games) {
   var games = [];
-  var ignBlocks = formatted_games.split(/(?!\([^)]*), (?![^(]*\))/);
+  var ignBlocks = _.compact(formatted_games.split(/(?!\([^)]*), (?![^(]*\))/));
   ignBlocks.forEach(function (block) {
     var parts = RegExp('^(' + exports.legalIgn + ')? ?(?:\\(((?:' + exports.gameOptions + ')(?:, (?:' + exports.gameOptions + '))*)\\))?$').exec(block);
     if (!parts) {


### PR DESCRIPTION
This would occur if a user was banned and they had never set a flair on either sub. The issue was that `Flairs.parseGames` would parse an empty-string flair text as `[{ign: undefined, game: ''}]` instead of realizing that the flair text contained no games.