### PR TITLE
Fix an issue where profiles couldn't be viewed in Firefox when the user was logged out

### DIFF
--- a/assets/userCtrl.js
+++ b/assets/userCtrl.js
@@ -365,6 +365,7 @@ module.exports = function ($scope, $location, io) {
   };
   $(document).ready(function () {
     $scope.loaded = true;
+    $scope.$apply();
     $('.plus-minus').parent().parent().on('click', function () {
       var plusminus = $(this).find('.plus-minus');
       plusminus.text(plusminus.text() === '+' ? '-' : '+');


### PR DESCRIPTION
So to be honest, I have no idea why this was working in Chrome and not Firefox, but this seems to fix it.