### PR TITLE
Fix for direct links to the set flair modal

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -28,6 +28,10 @@ var fapp = ng.module("fapp", [
   'fapp.md'
 ]);
 
+fapp.config(['$locationProvider', function($locationProvider) {
+  $locationProvider.hashPrefix('');
+}]);
+
 fapp.service('io', function () {
   var socket = require('socket.io-client');
   var io = require('sails.io.js')(socket);


### PR DESCRIPTION
Angular 1.5.9 changed the default hashPrefix from '' to '!' and our version range for angular caused us to go past that version, breaking the https://hq.porygon.co/#/flairtext link used for setting flair text.

This is the same solution we used [for Porybox](https://github.com/porybox/porybox/commit/f4f82bc1be2f0e34b3e22bc044b14efa9555c44c).