### PR TITLE
Updated search query for SVeX threads

### DIFF
--- a/api/services/Reddit.js
+++ b/api/services/Reddit.js
@@ -135,7 +135,7 @@ exports.editWikiPage = function (refreshToken, subreddit, page, content, reason)
 
 exports.searchTSVThreads = function (refreshToken, username) {
   var actual_sub = sails.config.debug.reddit ? sails.config.debug.subreddit : 'SVExchange';
-  var query = "(and (or (field flair 'banned') (field flair 'sv')) (field author '" + username + "'))";
+  var query = "(and (or flair_css_class:'banned' flair_css_class:'sv*') author:'" + username + "')";
   return exports.search(refreshToken, actual_sub, query, true, 'new', 'all', 'cloudsearch');
 };
 


### PR DESCRIPTION
Updated the search query for SVeX threads to hopefully provide better compatibility with [recent changes](https://www.reddit.com/r/changelog/comments/694o34/reddit_search_performance_improvements/) to the search engine. Unfortunately, the search engine is being very unpredictably at the moment, with the same query not always returning the same results if run consecutively. This still brings the current failure rate down somewhat from 100%, though, and should work properly once things are fixed.