### PR TITLE
Fix note overflow in public notes

### DIFF
--- a/assets/styles/bootstrap/panels.less
+++ b/assets/styles/bootstrap/panels.less
@@ -15,6 +15,7 @@
 // Panel contents
 .panel-body {
   padding: @panel-body-padding;
+  word-wrap: break-word;
   &:extend(.clearfix all);
 }
 


### PR DESCRIPTION
Added word wrap to the panel body so that it wouldn't overflow. Fixes #568

Preview: https://usercontent.irccloud-cdn.com/file/VFOS7dkA/image.png