### PR TITLE
Adjust flair mod permissions to allow for approving and denying apps

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -33,7 +33,9 @@ module.exports.policies = {
     '*': admin,
     applist: flairMod,
     apply: user,
-    setText: user
+    setText: user,
+    denyApp: flairMod,
+    approveApp: flairMod
   },
 
   HomeController: {


### PR DESCRIPTION
Adjust policies to allow flair mods to approve and deny apps (tested on local instance)