### PR TITLE
Update minimum Node.js version required to 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true
   matrix:
-    - export NODE_VERSION="4"
+    - export NODE_VERSION="6"
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Your first account will automatically get mod permission on both subreddits and 
 
 ### 2. Install prerequisites
 
-   Make sure you have Node.js ([some helpful guides here](https://nodejs.org/en/download/package-manager/)) and MongoDB ([check it here](https://docs.mongodb.com/manual/installation/)) installed. Node.js 4.0.0 or greater is required. Install git.
+   Make sure you have Node.js ([some helpful guides here](https://nodejs.org/en/download/package-manager/)) and MongoDB ([check it here](https://docs.mongodb.com/manual/installation/)) installed. Node.js 6.0.0 or greater is required. Install git.
    
 ### 3. Prepare the application folder 
 


### PR DESCRIPTION
Fixes the build tests, which fail after updating npm due to npm changes that break compatibility with Node 4.x.