### PR TITLE
Workaround for mobile layout issues

### DIFF
--- a/assets/styles/bootstrap/navbar.less
+++ b/assets/styles/bootstrap/navbar.less
@@ -51,8 +51,6 @@
   overflow-x: visible;
   padding-right: @navbar-padding-horizontal;
   padding-left:  @navbar-padding-horizontal;
-  border-top: 1px solid transparent;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.1);
   &:extend(.clearfix all);
   -webkit-overflow-scrolling: touch;
 
@@ -300,10 +298,6 @@
   margin-left: -@navbar-padding-horizontal;
   margin-right: -@navbar-padding-horizontal;
   padding: 10px @navbar-padding-horizontal;
-  border-top: 1px solid transparent;
-  border-bottom: 1px solid transparent;
-  @shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1);
-  .box-shadow(@shadow);
 
   // Mixin behavior for optimum display
   .form-inline();
@@ -662,6 +656,11 @@
       &:focus {
         color: @navbar-inverse-link-disabled-color;
       }
+    }
+  }
+  #main-navbar {
+    @media (max-width: @screen-xs-max) {
+      padding-top: 35px;
     }
   }
 }

--- a/assets/styles/bootstrap/navbar.less
+++ b/assets/styles/bootstrap/navbar.less
@@ -51,6 +51,9 @@
   overflow-x: visible;
   padding-right: @navbar-padding-horizontal;
   padding-left:  @navbar-padding-horizontal;
+  border-top: 0px solid transparent;
+  box-shadow: inset 0 0px 0 rgba(255,255,255,.1);
+
   &:extend(.clearfix all);
   -webkit-overflow-scrolling: touch;
 
@@ -298,6 +301,11 @@
   margin-left: -@navbar-padding-horizontal;
   margin-right: -@navbar-padding-horizontal;
   padding: 10px @navbar-padding-horizontal;
+  border-top: 0px solid transparent;
+  border-bottom: 0px solid transparent;
+  @shadow: inset 0 0px 0 rgba(255,255,255,.1), 0 0px 0 rgba(255,255,255,.1);
+  .box-shadow(@shadow);
+
 
   // Mixin behavior for optimum display
   .form-inline();

--- a/assets/styles/bootstrap/variables.less
+++ b/assets/styles/bootstrap/variables.less
@@ -305,7 +305,7 @@
 @grid-gutter-width:         30px;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
-@grid-float-breakpoint:     @screen-sm-min;
+@grid-float-breakpoint:     @screen-md-min;
 //** Point at which the navbar begins collapsing.
 @grid-float-breakpoint-max: (@grid-float-breakpoint - 1);
 


### PR DESCRIPTION
Regarding #541. 

* Removed border and its shadow from menu 
* Added 35px to `#main-navbar` to avoid overflowing the logo (on mobile)
* Enabled hamburger menu for tablets too

Some screenshots:
![2018-06-28 22_11_54-xubuntu64 uruchomiona - oracle vm virtualbox](https://user-images.githubusercontent.com/15113729/42058644-5726ece6-7b21-11e8-9e18-795fbe6d1bd6.png)

![2018-06-28 22_12_47-xubuntu64 uruchomiona - oracle vm virtualbox](https://user-images.githubusercontent.com/15113729/42058662-61a152f6-7b21-11e8-96af-ff1cab18ff37.png)

