### PR TITLE
Fix usernote alt bug

### DIFF
--- a/api/controllers/FlairController.js
+++ b/api/controllers/FlairController.js
@@ -151,9 +151,11 @@ module.exports = {
         if (users_with_matching_fcs.length !== 0) {
           message += 'This flair contains a friend code that matches ' + '/u/' + matching_fc_usernames.join(', /u/') + '\'s friend code: ' + matching_friend_codes + '\n\n';
           var altNote = "Alt of " + matching_fc_usernames;
-          promises.push(Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', req.user.name, altNote, 'spamwarn', ''));
+          promises.push(await Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', req.user.name, altNote, 'spamwarn', ''));
           var otherAltNote = "Alt of " + req.user.name;
-          promises.push(Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', matching_fc_usernames, otherAltNote, 'spamwarn', ''));
+          matching_fc_usernames.forEach(async function(entry){
+            promises.push(await Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', entry, otherAltNote, 'spamwarn', ''));
+          });
           if (identical_banned_fcs.length) {
             message += '**This flair contains a banned friend code: ' + identical_banned_fcs + '**\n\n';
           } else if (flagged.length && similar_banned_fcs.length) {
@@ -162,8 +164,10 @@ module.exports = {
         }
         if (matching_ip_usernames.length !== 0) {
           message += 'This user may be an alt of the user' + (matching_ip_usernames.length === 1 ? '' : 's') + ' /u/' + matching_ip_usernames.join(', /u/') + '.\n\n';
-          promises.push(Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', req.user.name, altNote, 'spamwarn', ''));
-          promises.push(Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', matching_fc_usernames, otherAltNote, 'spamwarn', ''));
+          promises.push(await Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', req.user.name, altNote, 'spamwarn', ''));
+          matching_ip_usernames.forEach(async function(entry){
+            promises.push(await Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', entry, otherAltNote, 'spamwarn', ''));
+          });
           if (matching_ip_banned_users.length) {
             message += '**' + '/u/' + matching_ip_banned_users.map(user => user.name).join(', /u/') + ' is banned.**\n\n';
           }
@@ -171,7 +175,7 @@ module.exports = {
         if (flagged.length) {
           message += 'The friend code' + (flagged.length === 1 ? ' ' + flagged + ' is' : 's ' + flagged.join(', ') + ' are') + ' invalid.\n\n';
           var formattedNote = "Invalid friend code" + (flagged.length == 1 ? "" : "s") + ": " + flagged.join(', ');
-          promises.push(Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', req.user.name, formattedNote, 'spamwarn', ''));
+          promises.push(await Usernotes.addUsernote(refreshToken, 'FlairHQ', 'pokemontrades', req.user.name, formattedNote, 'spamwarn', ''));
         }
         message = message.slice(0,-2);
         promises.push(Reddit.sendPrivateMessage(refreshToken, "FlairHQ notification", message, "/r/pokemontrades"));


### PR DESCRIPTION
I found that the issue is that usernotes are added in parallel so the latter is overwriting the former (visible in wiki page revision history). Another issue was that when user has two alts, only one note is added with `user1,user2` as username.

Tested for account with one alt (don't have the third account yet).