### PR TITLE
Fix banlist trailing pipe bug

### DIFF
--- a/api/services/Ban.js
+++ b/api/services/Ban.js
@@ -95,6 +95,9 @@ exports.updateBanlist = async function (redToken, username, banlistEntry, friend
         ||_.intersection(lines[i].match(/(\d{4}-){2}\d{4}/g), friend_codes).length) {
       // User was an alt account, modify the existing line instead of creating a new one
       let blocks = lines[i].split(/\s*\|\s*/);
+      if (blocks.length === 6 && !(blocks[5])) { // to handle banlist entries with | at the end
+        blocks.pop();
+      }
       let user_regex = '(?:^|\\s)('+username+(knownAlt ? '|'+knownAlt : '')+')(?:,|$)';
       let fc_match = _.intersection(blocks[1].match(/(\d{4}-){2}\d{4}/g), friend_codes).length;
       if (blocks.length !== 5 || !(fc_match || blocks[0].match(new RegExp(user_regex)))) {


### PR DESCRIPTION
Added support for entries with `|` (pipe) at the end of the line. 

Currently such entries are being skipped due to this:
https://github.com/pokemontrades/flairhq/blob/02a07783a4d082c6c7be331832ac2f0fc5b47cc8/api/services/Ban.js#L100-L102 