### PR TITLE
Flair-based Discord roles for pokemontrades

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -93,11 +93,11 @@ module.exports = {
       }
     })(req, res);
   },
-  
+
   discordCallback: async function (req, res) {
     const code = req.allParams().code;
     const user = req.user;
-    const ptradesFlair = user.flair.ptrades.flair_text;
+    const ptradesFlair = user.flair.ptrades.flair_css_class;
     const svexFlair = user.flair.svex.flair_text;
     if (!code) {
       return res.view(403, {error: 'Sorry, something went wrong. Please try again.'});
@@ -110,7 +110,8 @@ module.exports = {
       const accessToken = response.access_token;
       const currentUser = await Discord.getCurrentUser(accessToken);
       const nick = req.user.name;
-      const joinedUser = await Discord.addUserToGuild(accessToken, currentUser.id, nick);
+      const ptradesRoles = Discord.getUserRoles(ptradesFlair)
+      const joinedUser = await Discord.addUserToGuild(accessToken, currentUser.id, nick, ptradesRoles);
       const serverUrl = 'https://discordapp.com/channels/' + sails.config.discord.server_id;
       if (!joinedUser) {
         return res.redirect(serverUrl);

--- a/api/services/Discord.js
+++ b/api/services/Discord.js
@@ -107,21 +107,40 @@ exports.getCurrentUser = async function (token) {
   }
 };
 
-exports.addUserToGuild = async function (token, user, nick) {
+exports.getUserRoles = function (css_class) {
+
+  var userRoles = [];
+  var roleMap = sails.config.discord.flairRoleMap;
+
+  let class_array = css_class.split(' ');
+  for (let single_class of class_array) {
+    if (Flairs.hasInvolvement(single_class)) {
+      userRoles.push(roleMap['involvement'])
+      single_class = single_class.slice(0, -1)
+    }
+    if (roleMap[single_class]) {
+      userRoles.push(roleMap[single_class])
+    }
+  }
+  return userRoles;
+}
+
+exports.addUserToGuild = async function (token, user, nick, flairRoles) {
   const route = 'https://discordapp.com/api/guilds/' + sails.config.discord.server_id + '/members';
   const url =  route + '/' + user;
   const auth = 'Bot ' + sails.config.discord.bot_token;
-  const body = { 
+
+  const body = {
     'access_token': token,
     'nick': nick,
-    'roles' : sails.config.discord.authenticatedRole_id
+    'roles' : sails.config.discord.authenticatedRole_id.concat(flairRoles)
   };
   const headers = {
     "Authorization": auth,
     "Content-Type": "application/json"
   };
   try {
-    const response = await makeRequest('PUT', url, body, headers, route); 
+    const response = await makeRequest('PUT', url, body, headers, route);
     return response;
   } catch (err) {
     sails.log(err);

--- a/config/local.example.js
+++ b/config/local.example.js
@@ -34,6 +34,20 @@ module.exports = {
     redirect_host: 'http://localhost:1337',
     server_id: '111111',
     authenticatedRole_id: ['2222222'],
-    bot_token: 'aaaaaaaaaaa'
+    bot_token: 'aaaaaaaaaaa',
+    flairRoleMap: {
+      'default' : '333333',
+      'gen2' : '444444',
+      'pokeball' : '555555',
+      'premierball' : '666666',
+      'greatball' : '777777',
+      'ultraball' : '888888',
+      'luxuryball' : '999999',
+      'masterball' : '000000',
+      'dreamball' : '111111',
+      'cherishball' : '222222',
+      'ovalcharm' : '333333',
+      'shinycharm' : '444444',
+      'involvement': '555555'
   }
 };


### PR DESCRIPTION
Initial support for Discord roles based on flair for pokemontrades.

Todo:

- [x] Grant correct roles when joining the server
- [ ] Upgrade roles when approving a flair app


(Note that this uses `hasInvolvement` from #659, which isn't merged yet)